### PR TITLE
Removed PostInstall script for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "course.thesis",
   "version": "1.0.0",
   "scripts": {
-    "postinstall": "curl -s https://raw.githubusercontent.com/reactorcore/pomander/master/bin/install | bash",
     "start": "nodemon server",
     "test": " mocha ./server --recursive  jest --testPathPattern ./client/test\/.js  NODE_ENV=test grunt test",
 


### PR DESCRIPTION
Heroku deployment breaks if the pomander script is included in the package.json. The PR removes it. 